### PR TITLE
Pre-select detector for active runs, exclude failed runs

### DIFF
--- a/gemviz/tapi.py
+++ b/gemviz/tapi.py
@@ -184,7 +184,7 @@ class RunMetadata:
 
         status = self.get_run_md("stop", "exit_status")
         plot_signal = None
-        if status in "abort success".split():
+        if status != "fail":
             # These runs probably have plottable data fields.
 
             # Do not choose any of these fields as the default


### PR DESCRIPTION
- close #238 

Change plottable_signals() to pre-select detectors for active runs (status=None) and successful/aborted runs, while excluding failed runs.

Previously, only runs with exit_status 'abort' or 'success' had pre-selected detectors. Active runs (no stop document) had no detector pre-selected. This change makes behavior consistent between active and inactive runs, while excluding failed runs that may have incomplete data.