### PR TITLE
Fix filter fields expansion on macOS

### DIFF
--- a/gemviz/resources/bluesky_runs_catalog_search.ui
+++ b/gemviz/resources/bluesky_runs_catalog_search.ui
@@ -7,13 +7,16 @@
     <x>0</x>
     <y>0</y>
     <width>412</width>
-    <height>187</height>
+    <height>167</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::ExpandingFieldsGrow</enum>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="toolTip">


### PR DESCRIPTION
Set `QFormLayout fieldGrowthPolicy` to `ExpandingFieldsGrow` to allow filter fields to expand horizontally on macOS.  No changes on Linux. 

Before on MacOS:

<img width="1486" height="971" alt="image" src="https://github.com/user-attachments/assets/763844a3-fca6-4001-ba1a-fecb77a0ffd5" />


After on MacOS:
<img width="615" height="612" alt="image" src="https://github.com/user-attachments/assets/beed80d0-f01c-4ea2-8d42-8359910e4d85" />

After on Linux:
<img width="837" height="693" alt="image" src="https://github.com/user-attachments/assets/067742b7-9f42-4a65-bdf2-e7b60d36c261" />

