### PR TITLE
Add I0 normalization for plots and fix live field selection

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,7 +8,7 @@
 import pathlib
 import sys
 import tomllib
-from importlib.metadata import version
+from importlib.metadata import version as distribution_version
 
 sys.path.insert(0, str(pathlib.Path().absolute().parent.parent))
 import gemviz  # noqa
@@ -33,7 +33,7 @@ github_url = f"https://github.com/{gh_org}/{project}"
 # -- Special handling for version numbers ------------------------------------
 # https://github.com/pypa/setuptools_scm#usage-from-sphinx
 
-release = version(project)
+release = distribution_version(project)
 version = ".".join(release.split(".")[:2])
 
 # -- General configuration ---------------------------------------------------
@@ -71,6 +71,7 @@ autodoc_mock_imports = """
     numpy
     PyQt5
     pyRestTable
+    scipy
     spec2nexus
     tiled
     xarray

--- a/gemviz/bluesky_runs_catalog.py
+++ b/gemviz/bluesky_runs_catalog.py
@@ -168,6 +168,7 @@ class BRC_MVC(QtWidgets.QWidget):
             self.last_selected_fields[stream_name] = {
                 "X": selections.get("X"),  # Can be None
                 "Y": selections.get("Y", []).copy(),  # Copy to avoid reference issues
+                "I0": selections.get("I0"),  # Can be None
             }
             self.last_selected_stream = stream_name
 
@@ -187,8 +188,9 @@ class BRC_MVC(QtWidgets.QWidget):
                 # Build mapping of curve labels to field names for live updates
                 x_field = selections.get("X")
                 y_fields = selections.get("Y", [])
+                i0_field = selections.get("I0")
                 logger.info(
-                    f"Live plotting setup: x_field={x_field}, y_fields={y_fields}"
+                    f"Live plotting setup: x_field={x_field}, y_fields={y_fields}, i0_field={i0_field}"
                 )
 
                 live_data_fields = {}
@@ -197,9 +199,9 @@ class BRC_MVC(QtWidgets.QWidget):
                     # Map each dataset to its corresponding y_field
                     if len(y_fields) > 0 and i < len(y_fields):
                         y_field = y_fields[i]
-                        live_data_fields[label] = (x_field, y_field)
+                        live_data_fields[label] = (x_field, y_field, i0_field)
                         logger.info(
-                            f"Live field mapping: {label} -> ({x_field}, {y_field})"
+                            f"Live field mapping: {label} -> ({x_field}, {y_field}, {i0_field})"
                         )
 
                 if live_data_fields:

--- a/gemviz/chartview.py
+++ b/gemviz/chartview.py
@@ -273,7 +273,7 @@ class ChartView(QtWidgets.QWidget):
         self.live_timer = None
         self.live_run = None
         self.live_stream_name = None
-        self.live_data_fields = {}  # Maps label -> (x_field, y_field)
+        self.live_data_fields = {}  # Maps label -> (x_field, y_field, i0_field)
         self.field_widget = None
         self.update_interval = 2000  # milliseconds (2 seconds)
 
@@ -861,7 +861,8 @@ class ChartView(QtWidgets.QWidget):
             # Get selected curve ID
             selected_curveID = self.getSelectedCurveID()
 
-            for label, (x_field, y_field) in self.live_data_fields.items():
+            for label, (x_field, y_field, *_i0) in self.live_data_fields.items():
+                i0_field = _i0[0] if _i0 else None
                 # Get curveID from label
                 curveID = self.getCurveIDFromLabel(label)
                 if not curveID:
@@ -884,9 +885,19 @@ class ChartView(QtWidgets.QWidget):
                         )
                         continue
 
+                    if i0_field and i0_field not in stream_data:
+                        logger.debug(f"I0 field {i0_field} not yet in live stream data")
+                        continue
+
                     # Get raw data from stream (not transformed)
                     x_data = numpy.asarray(stream_data[x_field])
                     y_data = numpy.asarray(stream_data[y_field])
+
+                    if i0_field:
+                        i0_data = numpy.asarray(stream_data[i0_field])
+                        min_len = min(len(y_data), len(i0_data))
+                        y_data = y_data[:min_len] / i0_data[:min_len]
+                        x_data = x_data[:min_len]
 
                     if (
                         x_data.ndim != 0

--- a/gemviz/select_stream_fields.py
+++ b/gemviz/select_stream_fields.py
@@ -28,6 +28,7 @@ STREAM_COLUMNS = [
     TableColumn("Field", ColumnDataType.text),
     TableColumn("X", ColumnDataType.checkbox, rule=FieldRuleType.unique),
     TableColumn("Y", ColumnDataType.checkbox, rule=FieldRuleType.multiple),
+    TableColumn("I0", ColumnDataType.checkbox, rule=FieldRuleType.unique),
     TableColumn("Shape", ColumnDataType.text),
 ]
 
@@ -121,9 +122,11 @@ class SelectFieldsWidget(QtWidgets.QWidget):
         # Get preferred fields for this stream (if any)
         preferred_x = None
         preferred_y = []
+        preferred_i0 = None
         if self.preferred_fields is not None:
             preferred_x = self.preferred_fields.get("X")
             preferred_y = self.preferred_fields.get("Y", [])
+            preferred_i0 = self.preferred_fields.get("I0")
 
         # Check if any preferred Y detectors exist in current scan
         has_preferred_x = False
@@ -142,6 +145,8 @@ class SelectFieldsWidget(QtWidgets.QWidget):
                     selection = "X"
                 elif field_name in preferred_y:
                     selection = "Y"
+                elif preferred_i0 is not None and field_name == preferred_i0:
+                    selection = "I0"
                 # Fall back to default X if preferred_x is not in sdf
                 elif (
                     not has_preferred_x
@@ -199,6 +204,13 @@ class SelectFieldsWidget(QtWidgets.QWidget):
 
     def relayPlotSelections(self, stream_name, action, selections):
         """Receive selections from the dialog and relay to the caller."""
+        # Keep preferred fields synchronized with current user selections so
+        # live-table rebuilds do not revert to stale initial preferences.
+        self.preferred_fields = {
+            "X": selections.get("X"),
+            "Y": selections.get("Y", []).copy(),
+            "I0": selections.get("I0"),
+        }
         # selections["stream_name"] = self.stream_name
         self.selected.emit(stream_name, action, selections)
 
@@ -221,6 +233,17 @@ class SelectFieldsWidget(QtWidgets.QWidget):
                     self.table_view = None
                     saved = {}
 
+            # Checkbox toggles do not emit `selected` (only Replace/Add/Remove do),
+            # so `preferred_fields` can stay stale. Rebuild uses `preferred_fields`
+            # to seed TableField.selection — without this, clearing I0 during live
+            # mode would revert on the next timer tick.
+            if saved:
+                self.preferred_fields = {
+                    "X": saved.get("X"),
+                    "Y": list(saved.get("Y", [])),
+                    "I0": saved.get("I0"),
+                }
+
             # Rebuild the table for the current stream using fresh data.
             # setStream() will check if fields are readable before rebuilding
             current_stream = self.stream_name
@@ -238,6 +261,9 @@ class SelectFieldsWidget(QtWidgets.QWidget):
                         for y_field in saved.get("Y", []):
                             if y_field in fields:
                                 model.setSelectionsItem(fields.index(y_field), "Y")
+                        i0_field = saved.get("I0")
+                        if i0_field and i0_field in fields:
+                            model.setSelectionsItem(fields.index(i0_field), "I0")
                         model.updateCheckboxes()
                 except RuntimeError:
                     logger.debug(
@@ -314,6 +340,9 @@ def to_datasets(run, stream_name, selections, scan_id=None):
                 list(map(datetime.datetime.fromtimestamp, numpy.asarray(x_data)))
             )
 
+    i0_field = selections.get("I0")
+    i0_data = get_field_array(i0_field) if i0_field else None
+
     datasets = []
     y_selections = selections.get("Y", [])
     if len(y_selections) == 0:
@@ -333,6 +362,13 @@ def to_datasets(run, stream_name, selections, scan_id=None):
                     "Can only plot 1-D data now."
                     f" {y_axis} shape is {y_shape}"
                 )
+            if i0_data is not None:
+                if i0_data.shape != y_data.shape:
+                    raise ValueError(
+                        f"I0 field '{i0_field}' shape {i0_data.shape} does not match"
+                        f" Y field '{y_axis}' shape {y_data.shape}."
+                    )
+                y_data = y_data / i0_data
         except Exception as exc:
             raise ValueError(f"Failed to get fresh data for {y_axis}: {exc}")
 
@@ -341,7 +377,10 @@ def to_datasets(run, stream_name, selections, scan_id=None):
         # verbose labels
         # ds_options["label"] = f"{y_axis} ({run.summary()} {run.uid[:7]})"
         # terse labels
-        ds_options["label"] = f"{scan_id} ({run.uid[:7]}) - {y_axis}"
+        if i0_field:
+            ds_options["label"] = f"{scan_id} ({run.uid[:7]}) - {y_axis}/{i0_field}"
+        else:
+            ds_options["label"] = f"{scan_id} ({run.uid[:7]}) - {y_axis}"
         ds_options["color"] = color  # line color
         ds_options["marker"] = symbol
         ds_options["markersize"] = 5  # default: 10
@@ -375,6 +414,7 @@ def to_datasets(run, stream_name, selections, scan_id=None):
         "x": x_axis,
         "y_units": y_units,
         "y": ", ".join(selections.get("Y", [])),
+        "i0": i0_field,
     }
 
     return datasets, plot_options

--- a/gemviz/user_settings.py
+++ b/gemviz/user_settings.py
@@ -85,11 +85,14 @@ class ApplicationQSettings(QtCore.QSettings):
         self.init_global_keys()
 
     def __repr__(self):
-        keys = "fileName applicationName organizationName status".split()
-        d = {k: getattr(self, k)() for k in keys}
-        d.update(self.to_dict())
-        dl = ", ".join([f"{k}={v!r}" for k, v in d.items()])
-        return f"{self.__class__.__name__}({dl})"
+        try:
+            keys = "fileName applicationName organizationName status".split()
+            d = {k: getattr(self, k)() for k in keys}
+            d.update(self.to_dict())
+            dl = ", ".join([f"{k}={v!r}" for k, v in d.items()])
+            return f"{self.__class__.__name__}({dl})"
+        except Exception:
+            return f"{self.__class__.__name__}()"
 
     def to_dict(self):
         """Return a dict with all the settings."""


### PR DESCRIPTION
- close #289 

    - Add optional I0 column in stream field picker; divide Y by I0 in `to_datasets` with shape checks; reflect I0 in labels and `plot_options`
    - Pass I0 through live plot field mapping; apply normalization on live refresh
    - Keep checkbox state across table rebuilds: sync `preferred_fields` from current model before `setStream,` restore I0 after refresh, update on Replace emit